### PR TITLE
configure k8s CI step for self-hosted

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,3 +36,17 @@ jobs:
           target: production
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  deployment:
+    needs: build
+    runs-on:
+      - self-hosted
+      - airline-service-k8s
+    steps:
+      - name: Rollout restart
+        run: |
+          set -ex
+          cd $HOME
+          wget https://dl.k8s.io/release/v1.26.0/bin/linux/arm64/kubectl
+          chmod +x ./kubectl
+          ~/kubectl rollout restart deployment airline-service-v1 -n default


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a deployment step to the Docker workflow and restarts the deployment of the airline-service-v1 in the Kubernetes cluster.

### Detailed summary
- Added deployment step to the Docker workflow.
- Added `needs` parameter to ensure the build step is completed before deployment.
- Added `runs-on` parameter to specify the self-hosted and airline-service-k8s environments.
- Added a `Rollout restart` step to restart the deployment of airline-service-v1 in the default namespace of the Kubernetes cluster.
- Downloaded and installed `kubectl` to execute the `rollout restart` command.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->